### PR TITLE
Fix token output format

### DIFF
--- a/migration.rb
+++ b/migration.rb
@@ -110,7 +110,7 @@ class XeroOauthMigration
     request.body = params.to_json
     response = http.request(request)
 
-    return response.body
+    return JSON.parse(response.body)
   end
 end
 


### PR DESCRIPTION
This fix simply parses the response obtained from Xero as JSON. The knock-on effect being that `JSON.pretty_generate` will correctly output the tokens in a human-readable fashion.

Before:

```json
"{\"access_token\":\"xxxxxxxxxx.xxxxxxxxxx\",\"refresh_token\":\"xxxxxxxxxx\",\"expires_in\":\"1800\",\"token_type\":\"Bearer\",\"xero_tenant_id\":\"xxxx-xxxx-xxxx-xxxx-xxxxxxxxx\"}"
```

After:

```json
[
  { 
    "access_token": "xxxxxxxxxx.xxxxxxxxxx",
    "refresh_token": "xxxxxxxxxx",
    "expires_in": "1800",
    "token_type": "Bearer",
    "xero_tenant_id": "xxxx-xxxx-xxxx-xxxx-xxxxxxxxx"
  }
]
```